### PR TITLE
Fix compatability with beets v2.4.0

### DIFF
--- a/src/beetsplug/stylize/plugin.py
+++ b/src/beetsplug/stylize/plugin.py
@@ -22,7 +22,7 @@ import confuse  # type: ignore
 from beets import config  # type: ignore
 from beets.plugins import BeetsPlugin  # type: ignore
 from beets.ui import CODE_BY_COLOR  # type: ignore
-from beets.ui import _colorize
+from beets.ui import colorize
 
 
 BeetsColor = Literal["auto", "always", "never"]
@@ -100,7 +100,7 @@ class StylizePlugin(BeetsPlugin):  # type: ignore
             if code is None:
                 return text
             else:
-                return _colorize(code, text)  # type: ignore
+                return colorize(code, text)  # type: ignore
         else:
             return ""
 

--- a/src/beetsplug/stylize/plugin.py
+++ b/src/beetsplug/stylize/plugin.py
@@ -12,7 +12,7 @@ import os
 import sys
 import urllib.parse
 from functools import lru_cache
-from typing import List
+from typing import List, Tuple
 from typing import Literal
 from typing import Optional
 from typing import cast
@@ -122,7 +122,7 @@ class StylizePlugin(BeetsPlugin):  # type: ignore
 
     @staticmethod
     @lru_cache
-    def color_codes(color_name: str) -> Optional[List[str]]:
+    def color_codes(color_name: str) -> Optional[Tuple[str, ...]]:
         """Get configured color codes for a color name."""
         try:
             color_code: str = config["ui"]["colors"][color_name].get(str)
@@ -141,4 +141,4 @@ class StylizePlugin(BeetsPlugin):  # type: ignore
             if code not in CODE_BY_COLOR.keys():
                 raise ValueError("no such ANSI code %s", code)
 
-        return color_code_list
+        return tuple(color_code_list)

--- a/src/beetsplug/stylize/plugin.py
+++ b/src/beetsplug/stylize/plugin.py
@@ -96,11 +96,13 @@ class StylizePlugin(BeetsPlugin):  # type: ignore
     def stylize(self, color_name: str, text: str) -> str:
         """Colorize text with a configured color (ui.colors)."""
         if text:
-            code = self.color_codes(color_name)
-            if code is None:
+            color_names = self.color_codes(color_name)
+            if color_names is None:
                 return text
             else:
-                return colorize(code, text)  # type: ignore
+                # Convert color names to ANSI codes
+                codes = tuple(CODE_BY_COLOR[name] for name in color_names)
+                return colorize(codes, text)  # type: ignore
         else:
             return ""
 

--- a/src/beetsplug/stylize/plugin.py
+++ b/src/beetsplug/stylize/plugin.py
@@ -21,7 +21,7 @@ from typing import get_args
 import confuse  # type: ignore
 from beets import config  # type: ignore
 from beets.plugins import BeetsPlugin  # type: ignore
-from beets.ui import ANSI_CODES  # type: ignore
+from beets.ui import CODE_BY_COLOR  # type: ignore
 from beets.ui import _colorize
 
 
@@ -138,7 +138,7 @@ class StylizePlugin(BeetsPlugin):  # type: ignore
             color_code_list = color_code.split()
 
         for code in color_code_list:
-            if code not in ANSI_CODES.keys():
+            if code not in CODE_BY_COLOR.keys():
                 raise ValueError("no such ANSI code %s", code)
 
         return color_code_list


### PR DESCRIPTION
These are a couple changes to make the plugin compatable with beets v2.4.0. It looks like colorize also takes different inputs than the original _colorize, but my knowledge of Python is about reached.

The relevant pull request where they removed _colorize and renamed ANSI_CODES:
https://github.com/beetbox/beets/pull/5949

As of these fixes, attempting to `beet ls` produces the following error:
`<unhashable type: 'list'> <unhashable type: 'list'> <unhashable type: 'list'> <unhashable type: 'list'>`

Sorry I can't be more helpful but let me know if theres anything else I can help with! 